### PR TITLE
create endpoint medical record list

### DIFF
--- a/src/main/java/tech/lab365/labmedical/controllers/PatientController.java
+++ b/src/main/java/tech/lab365/labmedical/controllers/PatientController.java
@@ -2,8 +2,11 @@ package tech.lab365.labmedical.controllers;
 
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import tech.lab365.labmedical.dtos.MedicalRecordListResponseDTO;
 import tech.lab365.labmedical.dtos.PatientGetAllResponseDTO;
 import tech.lab365.labmedical.dtos.PatientRequestDTO;
 import tech.lab365.labmedical.dtos.PatientResponseDTO;
@@ -50,5 +53,15 @@ public class PatientController {
     public ResponseEntity<Void> deletePatient(@PathVariable Long id) {
         patientService.deletePatient(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/medical-record-list")
+    public ResponseEntity<Page<MedicalRecordListResponseDTO>> getAllMedicalRecords(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Long patient_id,
+            Pageable pageable
+    ) {
+        Page<MedicalRecordListResponseDTO> medicalRecords = patientService.getAllMedicalRecords(name, patient_id, pageable);
+        return ResponseEntity.ok(medicalRecords);
     }
 }

--- a/src/main/java/tech/lab365/labmedical/dtos/MedicalRecordListRequestDTO.java
+++ b/src/main/java/tech/lab365/labmedical/dtos/MedicalRecordListRequestDTO.java
@@ -1,0 +1,32 @@
+package tech.lab365.labmedical.dtos;
+
+public class MedicalRecordListRequestDTO {
+
+    private Long patientId;
+    private String name;
+    private String insurance;
+
+    public Long getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(Long patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getInsurance() {
+        return insurance;
+    }
+
+    public void setInsurance(String insurance) {
+        this.insurance = insurance;
+    }
+}

--- a/src/main/java/tech/lab365/labmedical/dtos/MedicalRecordListResponseDTO.java
+++ b/src/main/java/tech/lab365/labmedical/dtos/MedicalRecordListResponseDTO.java
@@ -1,0 +1,32 @@
+package tech.lab365.labmedical.dtos;
+
+public class MedicalRecordListResponseDTO {
+
+    private Long patientId;
+    private String name;
+    private String insurance;
+
+    public Long getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(Long patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getInsurance() {
+        return insurance;
+    }
+
+    public void setInsurance(String insurance) {
+        this.insurance = insurance;
+    }
+}

--- a/src/main/java/tech/lab365/labmedical/error/GlobalExceptionHandler.java
+++ b/src/main/java/tech/lab365/labmedical/error/GlobalExceptionHandler.java
@@ -35,6 +35,9 @@ public class GlobalExceptionHandler {
         if (e.getMessage().equals("Exam not found")) {
             return new ResponseEntity<>("The exam with the given ID was not found in database.", HttpStatus.NOT_FOUND);
         }
+        if (e.getMessage().equals("No patients found")) {
+            return new ResponseEntity<>("Your search returned no results.", HttpStatus.NOT_FOUND);
+        }
         return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 

--- a/src/main/java/tech/lab365/labmedical/mappers/PatientMapper.java
+++ b/src/main/java/tech/lab365/labmedical/mappers/PatientMapper.java
@@ -1,6 +1,7 @@
 package tech.lab365.labmedical.mappers;
 
 import org.springframework.stereotype.Component;
+import tech.lab365.labmedical.dtos.MedicalRecordListResponseDTO;
 import tech.lab365.labmedical.dtos.PatientGetAllResponseDTO;
 import tech.lab365.labmedical.dtos.PatientRequestDTO;
 import tech.lab365.labmedical.dtos.PatientResponseDTO;
@@ -108,6 +109,14 @@ public class PatientMapper {
         patient.setCity(dto.getCity());
         patient.setState(dto.getState());
         patient.setUser(user);
+    }
+
+    public MedicalRecordListResponseDTO toDTO(Patient patient) {
+        MedicalRecordListResponseDTO dto = new MedicalRecordListResponseDTO();
+        dto.setPatientId(patient.getPatientId());
+        dto.setName(patient.getName());
+        dto.setInsurance(patient.getHealthInsurance());
+        return dto;
     }
 
 }

--- a/src/main/java/tech/lab365/labmedical/repositories/PatientRepository.java
+++ b/src/main/java/tech/lab365/labmedical/repositories/PatientRepository.java
@@ -1,10 +1,21 @@
 package tech.lab365.labmedical.repositories;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import tech.lab365.labmedical.entities.Patient;
 
 public interface PatientRepository extends JpaRepository<Patient, Long> {
+
+    @Query("SELECT p FROM Patient p WHERE (:name is null or LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))) and (:patient_id is null or p.patient_id = :patient_id)")
+    Page<Patient> findByNameAndPatientId(@Param("name") String name, @Param("patient_id") Long patient_id, Pageable pageable);
+
+
 }
+
+
 
 
 

--- a/src/main/java/tech/lab365/labmedical/services/PatientService.java
+++ b/src/main/java/tech/lab365/labmedical/services/PatientService.java
@@ -2,7 +2,10 @@ package tech.lab365.labmedical.services;
 
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import tech.lab365.labmedical.dtos.MedicalRecordListResponseDTO;
 import tech.lab365.labmedical.dtos.PatientGetAllResponseDTO;
 import tech.lab365.labmedical.dtos.PatientRequestDTO;
 import tech.lab365.labmedical.dtos.PatientResponseDTO;
@@ -75,5 +78,15 @@ public class PatientService {
             throw new EntityNotFoundException("Patient not found");
         }
         patientRepository.deleteById(id);
+    }
+
+    public Page<MedicalRecordListResponseDTO> getAllMedicalRecords(String name, Long patient_id, Pageable pageable) {
+        Page<Patient> patients = patientRepository.findByNameAndPatientId(name, patient_id, pageable);
+
+        if (patients.isEmpty()) {
+            throw new EntityNotFoundException("No patients found");
+        }
+
+        return patients.map(patientMapper::toDTO);
     }
 }


### PR DESCRIPTION
Created the endpoint to list all patients, including name, patient_id and insurance, with pagination. Classes related to the Patient were used to handle this endpoint, as it returns data related to the patient. However, 2 new DTOs were created for this endpoint. The logic for using filter parameters was included in the repository.