### PR TITLE
fix: handle conflict when deleting patient with appointments or exams

### DIFF
--- a/src/main/java/tech/lab365/labmedical/controllers/PatientController.java
+++ b/src/main/java/tech/lab365/labmedical/controllers/PatientController.java
@@ -68,6 +68,8 @@ public class PatientController {
         return ResponseEntity.noContent().build();
     }
 
+
+
     @GetMapping("/medical-record-list")
     public ResponseEntity<Page<MedicalRecordListResponseDTO>> getAllMedicalRecords(
             @RequestParam(required = false) String name,

--- a/src/main/java/tech/lab365/labmedical/error/GlobalExceptionHandler.java
+++ b/src/main/java/tech/lab365/labmedical/error/GlobalExceptionHandler.java
@@ -41,6 +41,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler({IllegalStateException.class})
+    public ResponseEntity<String> handleStateExceptions(IllegalStateException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
+    }
+
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
     public ResponseEntity<String> handleValidationExceptions(MethodArgumentNotValidException ex) {

--- a/src/main/java/tech/lab365/labmedical/repositories/AppointmentRepository.java
+++ b/src/main/java/tech/lab365/labmedical/repositories/AppointmentRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 public interface AppointmentRepository extends JpaRepository<Appointment, UUID> {
 
     List<Appointment> findByPatient_Id(UUID id);
+
+    boolean existsByPatient_Id(UUID id);
 }

--- a/src/main/java/tech/lab365/labmedical/repositories/ExamRepository.java
+++ b/src/main/java/tech/lab365/labmedical/repositories/ExamRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 public interface ExamRepository extends JpaRepository<Exam, UUID> {
 
     List<Exam> findByPatient_Id(UUID id);
+
+    boolean existsByPatient_Id(UUID id);
 }


### PR DESCRIPTION
Added IllegalStateException to signal conflict when attempting to delete a patient with linked records. Ensured the appropriate error message is returned in the response body when the conflict occurs.